### PR TITLE
Fix key name for search input escape handler

### DIFF
--- a/layout/AppBreadCrumb.tsx
+++ b/layout/AppBreadCrumb.tsx
@@ -74,7 +74,7 @@ const AppBreadcrumb = () => {
                                     placeholder="Search"
                                     onBlur={deactivateSearch}
                                     onKeyDown={(e) => {
-                                        if (e.key === 'ESCAPE') deactivateSearch();
+                                        if (e.key === 'Escape') deactivateSearch();
                                     }}
                                 />
                                 <i className="pi pi-search"></i>


### PR DESCRIPTION
## Summary
- use correct key name for the breadcrumb search input

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843a2e013488330be0cdbea36c70871