### PR TITLE
Fix mail reply send uses stale state

### DIFF
--- a/demo/components/apps/mail/AppMailReply.tsx
+++ b/demo/components/apps/mail/AppMailReply.tsx
@@ -28,14 +28,16 @@ function AppMailReply(props: AppMailReplyProps) {
     const { onSend, toastRef } = useContext(MailContext);
 
     const sendMail = () => {
-        let { image, from, title } = content as Demo.Mail;
-        setNewMail((prevState) => ({
-            ...prevState,
+        const { image, from, title } = content as Demo.Mail;
+        const updatedMail = {
+            ...newMail,
             to: from,
             title: title,
             image: image
-        }));
-        onSend(newMail);
+        };
+
+        setNewMail(updatedMail);
+        onSend(updatedMail);
 
         toastRef.current?.show({
             severity: 'success',


### PR DESCRIPTION
## Summary
- fix send mail function using stale state

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_6843a3686f108330b1951bb0a10367a2