### PR TITLE
Fix search toggle state update

### DIFF
--- a/layout/context/layoutcontext.tsx
+++ b/layout/context/layoutcontext.tsx
@@ -66,7 +66,7 @@ export const LayoutProvider = (props: ChildContainerProps) => {
     const toggleSearch = () => {
         setLayoutState((prevLayoutState) => ({
             ...prevLayoutState,
-            searchBarActive: !layoutState.searchBarActive
+            searchBarActive: !prevLayoutState.searchBarActive
         }));
     };
 


### PR DESCRIPTION
## Summary
- adjust `toggleSearch` logic to use previous state

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843a47383c483309f8ff26ff079528a