### PR TITLE
Update layout context doc extension

### DIFF
--- a/app/(main)/documentation/page.tsx
+++ b/app/(main)/documentation/page.tsx
@@ -171,7 +171,7 @@ export default function FullPageLayout({ children }: FullPageLayoutProps) {
 
             <h5>Default Configuration</h5>
             <p>
-                Initial layout configuration can be defined at the <span className="text-primary font-medium">layout/context/layoutcontext.js</span> file, this step is optional and only necessary when customizing the defaults.
+                Initial layout configuration can be defined at the <span className="text-primary font-medium">layout/context/layoutcontext.tsx</span> file, this step is optional and only necessary when customizing the defaults.
             </p>
 
             <pre className="app-code">


### PR DESCRIPTION
## Summary
- fix file extension in documentation for layout context

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843a477473883309ab2f9c4d7d9dca7