### PR TITLE
Move head meta tags to app layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,6 +13,24 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     return (
         <html lang="en" suppressHydrationWarning>
             <head>
+                <title>PrimeReact - DIAMOND</title>
+                <meta charSet="UTF-8" />
+                <meta
+                    name="description"
+                    content="The ultimate collection of design-agnostic, flexible and accessible React UI Components."
+                />
+                <meta name="robots" content="index, follow" />
+                <meta name="viewport" content="initial-scale=1, width=device-width" />
+                <meta property="og:type" content="website" />
+                <meta property="og:title" content="Diamond by PrimeReact for NextJS" />
+                <meta property="og:url" content="https://diamond.primereact.org" />
+                <meta
+                    property="og:description"
+                    content="The ultimate collection of design-agnostic, flexible and accessible React UI Components."
+                />
+                <meta property="og:image" content="https://www.primefaces.org/static/social/diamond-react.png" />
+                <meta property="og:ttl" content="604800" />
+                <link rel="icon" href={`/favicon.ico`} type="image/x-icon" />
                 <link id="theme-link" href={`/theme/theme-light/green/theme.css`} rel="stylesheet"></link>
             </head>
             <body>

--- a/layout/context/layoutcontext.tsx
+++ b/layout/context/layoutcontext.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import Head from 'next/head';
 import React, { useState } from 'react';
 import { Breadcrumb, LayoutConfig, LayoutContextProps } from '../../types/layout';
 import { ChildContainerProps } from '@/types';
@@ -138,24 +137,6 @@ export const LayoutProvider = (props: ChildContainerProps) => {
     };
 
     return (
-        <LayoutContext.Provider value={value}>
-            <>
-                <Head>
-                    <title>PrimeReact - DIAMOND</title>
-                    <meta charSet="UTF-8" />
-                    <meta name="description" content="The ultimate collection of design-agnostic, flexible and accessible React UI Components." />
-                    <meta name="robots" content="index, follow" />
-                    <meta name="viewport" content="initial-scale=1, width=device-width" />
-                    <meta property="og:type" content="website"></meta>
-                    <meta property="og:title" content="Diamond by PrimeReact for NextJS"></meta>
-                    <meta property="og:url" content="https://diamond.primereact.org"></meta>
-                    <meta property="og:description" content="The ultimate collection of design-agnostic, flexible and accessible React UI Components." />
-                    <meta property="og:image" content="https://www.primefaces.org/static/social/diamond-react.png"></meta>
-                    <meta property="og:ttl" content="604800"></meta>
-                    <link rel="icon" href={`/favicon.ico`} type="image/x-icon"></link>
-                </Head>
-                {props.children}
-            </>
-        </LayoutContext.Provider>
+        <LayoutContext.Provider value={value}>{props.children}</LayoutContext.Provider>
     );
 };


### PR DESCRIPTION
## Summary
- place static meta tags directly into `app/layout.tsx`
- remove `<Head>` import and JSX from layout context provider

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843a91f466c8330a99f3cd557dfe7bb