### PR TITLE
Fix sidebar timeout handling with useRef

### DIFF
--- a/layout/AppSidebar.tsx
+++ b/layout/AppSidebar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useContext, useEffect } from 'react';
+import { useContext, useEffect, useRef } from 'react';
 import AppMenu from './AppMenu';
 import { LayoutContext } from './context/layoutcontext';
 import { MenuProvider } from './context/menucontext';
@@ -31,13 +31,13 @@ const AppSidebar = (props: { sidebarRef: React.RefObject<HTMLDivElement> }) => {
         }
     };
 
-    let timeout = null;
+    const timeoutRef = useRef<NodeJS.Timeout | null>(null);
 
     const onMouseEnter = () => {
         if (!layoutState.anchored) {
-            if (timeout) {
-                clearTimeout(timeout);
-                timeout = null;
+            if (timeoutRef.current) {
+                clearTimeout(timeoutRef.current);
+                timeoutRef.current = null;
             }
             setLayoutState((prevLayoutState) => ({
                 ...prevLayoutState,
@@ -48,15 +48,15 @@ const AppSidebar = (props: { sidebarRef: React.RefObject<HTMLDivElement> }) => {
 
     const onMouseLeave = () => {
         if (!layoutState.anchored) {
-            if (!timeout) {
-                timeout = setTimeout(
+            if (!timeoutRef.current) {
+                timeoutRef.current = setTimeout(
                     () =>
                         setLayoutState((prevLayoutState) => ({
                             ...prevLayoutState,
                             sidebarActive: false
                         })),
                     300
-                );
+                ) as NodeJS.Timeout;
             }
         }
     };


### PR DESCRIPTION
## Summary
- use `useRef` for managing sidebar show/hide timeout

## Testing
- `npx prettier --write layout/AppSidebar.tsx`
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843b4afbd388330bd04b286b4409dd2