### PR TITLE
Fix layout hook imports

### DIFF
--- a/layout/hooks/useSubmenuOverlayPosition.tsx
+++ b/layout/hooks/useSubmenuOverlayPosition.tsx
@@ -2,12 +2,12 @@
 
 import { useEventListener } from 'primereact/hooks';
 import { DomHandler } from 'primereact/utils';
-import { useCallback, useContext, useEffect } from 'react';
+import { useContext, useEffect } from 'react';
 import { LayoutContext } from '../context/layoutcontext';
 import { MenuContext } from '../context/menucontext';
 
 export const useSubmenuOverlayPosition = ({ target, overlay, container, when }) => {
-    const { isSlim, isSlimPlus, isHorizontal, setLayoutState, layoutState } = useContext(LayoutContext);
+    const { isSlim, isSlimPlus, isHorizontal, setLayoutState } = useContext(LayoutContext);
     const { activeMenu } = useContext(MenuContext);
     const [bindScrollListener, unbindScrollListener] = useEventListener({
         type: 'scroll',


### PR DESCRIPTION
## Summary
- remove unused `useCallback` import
- stop pulling `layoutState` from `LayoutContext`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843b4be7cfc8330b27939031838fd2b