### PR TITLE
Use useMemo for layout context value

### DIFF
--- a/layout/context/layoutcontext.tsx
+++ b/layout/context/layoutcontext.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Head from 'next/head';
-import React, { useState } from 'react';
+import React, { useState, useMemo, useCallback } from 'react';
 import { Breadcrumb, LayoutConfig, LayoutContextProps } from '../../types/layout';
 import { ChildContainerProps } from '@/types';
 
@@ -33,7 +33,7 @@ export const LayoutProvider = (props: ChildContainerProps) => {
         rightMenuActive: false
     });
 
-    const onMenuToggle = (event: React.MouseEvent<HTMLButtonElement>) => {
+    const onMenuToggle = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
         if (isOverlay()) {
             setLayoutState((prevLayoutState) => ({
                 ...prevLayoutState,
@@ -53,89 +53,106 @@ export const LayoutProvider = (props: ChildContainerProps) => {
 
             event.preventDefault();
         }
-    };
+    }, [isOverlay, isDesktop]);
 
-    const hideOverlayMenu = () => {
+    const hideOverlayMenu = useCallback(() => {
         setLayoutState((prevLayoutState) => ({
             ...prevLayoutState,
             overlayMenuActive: false,
             staticMenuMobileActive: false
         }));
-    };
+    }, []);
 
-    const toggleSearch = () => {
+    const toggleSearch = useCallback(() => {
         setLayoutState((prevLayoutState) => ({
             ...prevLayoutState,
             searchBarActive: !layoutState.searchBarActive
         }));
-    };
+    }, [layoutState.searchBarActive]);
 
-    const onSearchHide = () => {
+    const onSearchHide = useCallback(() => {
         setLayoutState((prevLayoutState) => ({
             ...prevLayoutState,
             searchBarActive: false
         }));
-    };
+    }, []);
 
-    const showRightSidebar = () => {
+    const showRightSidebar = useCallback(() => {
         setLayoutState((prevLayoutState) => ({
             ...prevLayoutState,
             rightMenuActive: true
         }));
         hideOverlayMenu();
-    };
+    }, [hideOverlayMenu]);
 
-    const showConfigSidebar = () => {
+    const showConfigSidebar = useCallback(() => {
         setLayoutState((prevLayoutState) => ({
             ...prevLayoutState,
             configSidebarVisible: true
         }));
-    };
-    const showSidebar = () => {
+    }, []);
+    const showSidebar = useCallback(() => {
         setLayoutState((prevLayoutState) => ({
             ...prevLayoutState,
             rightMenuVisible: true
         }));
-    };
+    }, []);
 
-    const isOverlay = () => {
+    const isOverlay = useCallback(() => {
         return layoutConfig.menuMode === 'overlay';
-    };
+    }, [layoutConfig.menuMode]);
 
-    const isSlim = () => {
+    const isSlim = useCallback(() => {
         return layoutConfig.menuMode === 'slim';
-    };
+    }, [layoutConfig.menuMode]);
 
-    const isSlimPlus = () => {
+    const isSlimPlus = useCallback(() => {
         return layoutConfig.menuMode === 'slim-plus';
-    };
+    }, [layoutConfig.menuMode]);
 
-    const isHorizontal = () => {
+    const isHorizontal = useCallback(() => {
         return layoutConfig.menuMode === 'horizontal';
-    };
+    }, [layoutConfig.menuMode]);
 
-    const isDesktop = () => {
+    const isDesktop = useCallback(() => {
         return window.innerWidth > 991;
-    };
+    }, []);
 
-    const value = {
-        layoutConfig,
-        setLayoutConfig,
-        layoutState,
-        setLayoutState,
-        isSlim,
-        isSlimPlus,
-        isHorizontal,
-        isDesktop,
-        onMenuToggle,
-        toggleSearch,
-        onSearchHide,
-        showRightSidebar,
-        breadcrumbs,
-        setBreadcrumbs,
-        showConfigSidebar,
-        showSidebar
-    };
+    const value = useMemo(
+        () => ({
+            layoutConfig,
+            setLayoutConfig,
+            layoutState,
+            setLayoutState,
+            isSlim,
+            isSlimPlus,
+            isHorizontal,
+            isDesktop,
+            onMenuToggle,
+            toggleSearch,
+            onSearchHide,
+            showRightSidebar,
+            breadcrumbs,
+            setBreadcrumbs,
+            showConfigSidebar,
+            showSidebar
+        }),
+        [
+            layoutConfig,
+            layoutState,
+            breadcrumbs,
+            isSlim,
+            isSlimPlus,
+            isHorizontal,
+            isDesktop,
+            onMenuToggle,
+            toggleSearch,
+            onSearchHide,
+            showRightSidebar,
+            showConfigSidebar,
+            showSidebar
+        ]
+    );
 
     return (
         <LayoutContext.Provider value={value}>


### PR DESCRIPTION
## Summary
- memoize context value in `LayoutProvider`
- memoize helper callbacks

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68453449bf808330b17bf256abb41ca2