### PR TITLE
Use Next.js Image component for layout

### DIFF
--- a/layout/AppProfileMenu.tsx
+++ b/layout/AppProfileMenu.tsx
@@ -1,5 +1,6 @@
 import { Sidebar } from 'primereact/sidebar';
 import { useContext, useState } from 'react';
+import Image from 'next/image';
 import { LayoutContext } from './context/layoutcontext';
 import { Calendar } from 'primereact/calendar';
 
@@ -30,7 +31,7 @@ const AppProfileSidebar = () => {
             <div className="layout-rightmenu h-full overflow-y-auto overflow-x-hidden">
                 <div className="user-detail-wrapper text-center" style={{ padding: '4.5rem 0 2rem 0' }}>
                     <div className="user-detail-content mb-4">
-                        <img src="/layout/images/avatar/gene.png" alt="atlantis" className="user-image" />
+                        <Image src="/layout/images/avatar/gene.png" alt="atlantis" className="user-image" width={103} height={104} />
                         <span className="user-name text-2xl text-center block mt-4 mb-1">Gene Russell</span>
                         <span className="user-number">(406) 555-0120</span>
                     </div>

--- a/layout/AppSidebar.tsx
+++ b/layout/AppSidebar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Link from 'next/link';
+import Image from 'next/image';
 import { useContext, useEffect } from 'react';
 import AppMenu from './AppMenu';
 import { LayoutContext } from './context/layoutcontext';
@@ -67,11 +68,28 @@ const AppSidebar = (props: { sidebarRef: React.RefObject<HTMLDivElement> }) => {
                 <div className="sidebar-header">
                     <Link href="/" className="app-logo">
                         <div className="app-logo-small h-2rem">
-                            <img src={`/layout/images/logo/logo-${layoutConfig.colorScheme === 'light' ? 'dark' : 'light'}.png`} alt="Logo" />
+                            <Image
+                                src={`/layout/images/logo/logo-${layoutConfig.colorScheme === 'light' ? 'dark' : 'light'}.png`}
+                                alt="Logo"
+                                width={layoutConfig.colorScheme === 'light' ? 113 : 146}
+                                height={layoutConfig.colorScheme === 'light' ? 103 : 133}
+                            />
                         </div>
                         <div className="app-logo-normal">
-                            <img className="h-2rem" src={`/layout/images/logo/logo-${layoutConfig.colorScheme === 'light' ? 'dark' : 'light'}.png`} alt="logo" />
-                            <img className="h-2rem ml-3" src={`/layout/images/logo/appname-${layoutConfig.colorScheme === 'light' ? 'dark' : 'light'}.png`} alt="App Name Logo" />
+                            <Image
+                                className="h-2rem"
+                                src={`/layout/images/logo/logo-${layoutConfig.colorScheme === 'light' ? 'dark' : 'light'}.png`}
+                                alt="logo"
+                                width={layoutConfig.colorScheme === 'light' ? 113 : 146}
+                                height={layoutConfig.colorScheme === 'light' ? 103 : 133}
+                            />
+                            <Image
+                                className="h-2rem ml-3"
+                                src={`/layout/images/logo/appname-${layoutConfig.colorScheme === 'light' ? 'dark' : 'light'}.png`}
+                                alt="App Name Logo"
+                                width={layoutConfig.colorScheme === 'light' ? 235 : 304}
+                                height={layoutConfig.colorScheme === 'light' ? 47 : 60}
+                            />
                         </div>
                     </Link>
                     <button className="layout-sidebar-anchor p-link z-2" type="button" onClick={anchor}></button>

--- a/layout/AppTopbar.tsx
+++ b/layout/AppTopbar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { forwardRef, useImperativeHandle, useContext, useRef, useState } from 'react';
+import Image from 'next/image';
 
 import AppBreadCrumb from './AppBreadCrumb';
 import { LayoutContext } from './context/layoutcontext';
@@ -97,7 +98,13 @@ const AppTopbar = forwardRef((props: { sidebarRef: React.RefObject<HTMLDivElemen
                         <li ref={profileMenuRef} className="profile-item topbar-item">
                             <StyleClass nodeRef={profileRef} selector="@next" enterClassName="hidden" enterActiveClassName="px-scalein" leaveToClassName="hidden" leaveActiveClassName="px-fadeout" hideOnOutsideClick>
                                 <a className="p-ripple" ref={profileRef}>
-                                    <img className="border-circle cursor-pointer" src="/layout/images/avatar/avatar-m-1.jpg" alt="avatar" />
+                                    <Image
+                                        className="border-circle cursor-pointer"
+                                        src="/layout/images/avatar/avatar-m-1.jpg"
+                                        alt="avatar"
+                                        width={318}
+                                        height={308}
+                                    />
                                     <Ripple />
                                 </a>
                             </StyleClass>


### PR DESCRIPTION
## Summary
- use `next/image` in sidebar, profile menu and topbar
- provide image dimensions and alt text

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684534573c408330a34f6e7e1baccfd5