### PR TITLE
Use Next.js PageProps for mail detail

### DIFF
--- a/app/(main)/apps/(mail)/mail/detail/[mailId]/page.tsx
+++ b/app/(main)/apps/(mail)/mail/detail/[mailId]/page.tsx
@@ -8,16 +8,11 @@ import { Editor } from 'primereact/editor';
 import { Toast } from 'primereact/toast';
 import { MailContext } from '../../../../../../../demo/components/apps/mail/context/mailcontext';
 
+import type { PageProps } from 'next';
 import type { Demo } from '@/types';
 import { useSearchParams } from 'next/navigation';
 
-interface MailPageProps {
-    params: {
-        mailId: string;
-    };
-}
-
-const AppMailDetail = ({ params }: MailPageProps) => {
+const AppMailDetail = ({ params }: PageProps<{ mailId: string }>) => {
     const searchParams = useSearchParams();
 
     const toast = useRef<Toast | null>(null);


### PR DESCRIPTION
## Summary
- use `PageProps` from Next.js for mail detail page props

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848f71179c08330af2a3ab2ed312e38