### PR TITLE
Disable Next.js duplicate head lint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,6 +3,7 @@
     "rules": {
         "@next/next/no-img-element": "off",
         "@next/next/no-html-link-for-pages": "off",
-        "@next/next/no-page-custom-font": "off"
+        "@next/next/no-page-custom-font": "off",
+        "@next/next/no-duplicate-head": "off"
     }
 }


### PR DESCRIPTION
## Summary
- disable `@next/next/no-duplicate-head` in ESLint config

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848f7171e248330b1c23704ed3d6fe9