### PR TITLE
Update TypeScript dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "react-dom": "^18.2.0",
     "react-toastify": "^11.0.5",
     "tailwindcss": "^4.1.3",
-    "typescript": "5.0.4"
+    "typescript": "^5.2.0"
   },
   "devDependencies": {
     "eslint": "8.35.0",


### PR DESCRIPTION
## Summary
- bump `typescript` dependency to `^5.2.0`

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/typescript)*
- `npm run lint` *(fails: `next: not found`)*
- `npm run build` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6848f71ee9448330a099611c87d9597a